### PR TITLE
feat: Shell Layout 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ set_target_properties(sqlite3 PROPERTIES C_STANDARD 11)
 # ── Telescode executable ──────────────────────────────────────────────────────
 add_executable(Telescode
     src/main.cpp
+    src/ui/ts_app.cpp
     src/db/db.cpp
 )
 target_include_directories(Telescode PRIVATE

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 extern "C" const TSLanguage* tree_sitter_python();
 
 #include "ui/ts_style.h"
+#include "ui/ts_app.h"
 
 #ifdef TELESCODE_STYLE_PREVIEW
 #include "dev/style_preview.h"
@@ -24,7 +25,7 @@ int main(int, char**)
 
     SDL_Window* window = SDL_CreateWindow(
         "Telescode",
-        1280, 800,
+        1280, 900,
         SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY
     );
     if (!window) {
@@ -35,6 +36,7 @@ int main(int, char**)
     // DPI scale -- set before LoadFonts so font sizes are correct
     TS::ui_scale = SDL_GetDisplayContentScale(SDL_GetDisplayForWindow(window));
     if (TS::ui_scale < 0.5f) TS::ui_scale = 1.0f;
+    SDL_SetWindowMinimumSize(window, 0, (int)(900.0f * TS::ui_scale));
 
     SDL_GPUDevice* gpu = SDL_CreateGPUDevice(
         SDL_GPU_SHADERFORMAT_SPIRV | SDL_GPU_SHADERFORMAT_DXIL | SDL_GPU_SHADERFORMAT_METALLIB,
@@ -92,6 +94,8 @@ int main(int, char**)
         ImGui_ImplSDLGPU3_NewFrame();
         ImGui_ImplSDL3_NewFrame();
         ImGui::NewFrame();
+
+        TS::DrawAppShell();
 
 #ifdef TELESCODE_STYLE_PREVIEW
         TS::DrawStylePreview();

--- a/src/ui/ts_app.cpp
+++ b/src/ui/ts_app.cpp
@@ -19,7 +19,7 @@ namespace {
     constexpr float k_sidebar_w   = 280.0f;
     constexpr float k_icon_rail_w = 40.0f;
     constexpr float k_rail_h      = 120.0f;
-    constexpr float k_rail_strip  = 24.0f;
+    constexpr float k_rail_strip  = 32.0f;
     constexpr float k_toggle_h    = 32.0f;  // sidebar collapse button height
     constexpr float k_chevron_w   = 48.0f;  // rail chevron button width
 }

--- a/src/ui/ts_app.cpp
+++ b/src/ui/ts_app.cpp
@@ -86,13 +86,14 @@ void DrawAppShell()
                       {canvas_x + canvas_w, rail_y + rail_h},
                       TS::PANEL_U32);
 
-    // Chevron toggle: right edge of the rail.
+    // Chevron toggle: upper-right corner of the rail, fixed height.
     const float chev_w = k_chevron_w * s;
+    const float chev_h = k_toggle_h  * s;
     ImGui::SetCursorScreenPos({canvas_x + canvas_w - chev_w, rail_y});
     ImGui::PushStyleColor(ImGuiCol_Button,        TS::PANEL_2);
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, Darken(TS::PANEL_2, 0.06f));
     ImGui::PushStyleColor(ImGuiCol_ButtonActive,  Darken(TS::PANEL_2, 0.12f));
-    if (ImGui::Button(s_rail_collapsed ? "^##rail" : "v##rail", {chev_w, rail_h}))
+    if (ImGui::Button(s_rail_collapsed ? "^##rail" : "v##rail", {chev_w, chev_h}))
         s_rail_collapsed = !s_rail_collapsed;
     ImGui::PopStyleColor(3);
 

--- a/src/ui/ts_app.cpp
+++ b/src/ui/ts_app.cpp
@@ -1,0 +1,114 @@
+// src/ui/ts_app.cpp
+// Static app shell — five layout zones, collapse toggles, no content.
+//
+// Zone summary:
+//   Header        full width, 48px, always visible       (TS::HEADER)
+//   Sidebar       left, 280px | 40px icon rail           (TS::PANEL)
+//   Canvas        fills remaining space                   (TS::BG_SOFT)
+//   Toolbar       floating child, top-left of canvas     (TS::PANEL)
+//   Sequence rail bottom, 120px | 24px strip             (TS::PANEL)
+
+#include "ts_app.h"
+#include "ts_style.h"
+#include <imgui.h>
+
+namespace TS {
+
+namespace {
+    // 1x reference values — multiply by TS::ui_scale at every use site.
+    constexpr float k_header_h    = 48.0f;
+    constexpr float k_sidebar_w   = 280.0f;
+    constexpr float k_icon_rail_w = 40.0f;
+    constexpr float k_rail_h      = 120.0f;
+    constexpr float k_rail_strip  = 24.0f;
+    constexpr float k_toggle_h    = 32.0f;  // sidebar collapse button height
+    constexpr float k_chevron_w   = 48.0f;  // rail chevron button width
+    constexpr float k_toolbar_w   = 44.0f;
+    constexpr float k_toolbar_h   = 140.0f;
+    constexpr float k_pad         = 8.0f;   // toolbar inset from canvas edge
+}
+
+static bool s_sidebar_collapsed = false;
+static bool s_rail_collapsed    = false;
+
+void DrawAppShell()
+{
+    const float s  = TS::ui_scale;
+    const float dw = ImGui::GetIO().DisplaySize.x;
+    const float dh = ImGui::GetIO().DisplaySize.y;
+
+    const float header_h  = k_header_h * s;
+    const float sidebar_w = (s_sidebar_collapsed ? k_icon_rail_w : k_sidebar_w) * s;
+    const float rail_h    = (s_rail_collapsed    ? k_rail_strip  : k_rail_h)    * s;
+
+    const float body_y   = header_h;
+    const float body_h   = dh - header_h;
+    const float canvas_x = sidebar_w;
+    const float canvas_w = dw - sidebar_w;
+    // Guard: canvas_h never goes negative if window is smaller than expected.
+    const float canvas_h = (body_h > rail_h) ? (body_h - rail_h) : 0.0f;
+    const float rail_y   = body_y + canvas_h;
+
+    // Full-screen shell window — no decoration, not moveable, no saved layout.
+    ImGui::SetNextWindowPos({0.0f, 0.0f});
+    ImGui::SetNextWindowSize({dw, dh});
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,    {0.0f, 0.0f});
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+    ImGui::Begin("##shell", nullptr,
+        ImGuiWindowFlags_NoDecoration         |
+        ImGuiWindowFlags_NoMove               |
+        ImGuiWindowFlags_NoBringToFrontOnFocus |
+        ImGuiWindowFlags_NoSavedSettings);
+    ImGui::PopStyleVar(2);
+
+    ImDrawList* dl = ImGui::GetWindowDrawList();
+
+    // ── Header ───────────────────────────────────────────────────────────────
+    dl->AddRectFilled({0.0f, 0.0f}, {dw, header_h}, TS::HEADER_U32);
+
+    // ── Sidebar ──────────────────────────────────────────────────────────────
+    dl->AddRectFilled({0.0f, body_y}, {sidebar_w, body_y + body_h}, TS::PANEL_U32);
+
+    // Collapse toggle: button pinned to the bottom of the sidebar.
+    const float tgl_h = k_toggle_h * s;
+    const float tgl_y = body_y + body_h - tgl_h;
+    ImGui::SetCursorScreenPos({0.0f, tgl_y});
+    ImGui::PushStyleColor(ImGuiCol_Button,        TS::PANEL_2);
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, Darken(TS::PANEL_2, 0.06f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive,  Darken(TS::PANEL_2, 0.12f));
+    if (ImGui::Button(s_sidebar_collapsed ? ">##sb" : "<##sb", {sidebar_w, tgl_h}))
+        s_sidebar_collapsed = !s_sidebar_collapsed;
+    ImGui::PopStyleColor(3);
+
+    // ── Canvas ────────────────────────────────────────────────────────────────
+    dl->AddRectFilled({canvas_x, body_y},
+                      {canvas_x + canvas_w, body_y + canvas_h},
+                      TS::BG_SOFT_U32);
+
+    // ── Toolbar (floating child, overlaid on top-left of canvas) ─────────────
+    ImGui::SetCursorScreenPos({canvas_x + k_pad * s, body_y + k_pad * s});
+    ImGui::PushStyleColor(ImGuiCol_ChildBg, TS::PANEL);
+    ImGui::BeginChild("##toolbar", {k_toolbar_w * s, k_toolbar_h * s}, false,
+                      ImGuiWindowFlags_NoScrollbar);
+    ImGui::EndChild();
+    ImGui::PopStyleColor();
+
+    // ── Sequence Rail ─────────────────────────────────────────────────────────
+    dl->AddRectFilled({canvas_x, rail_y},
+                      {canvas_x + canvas_w, rail_y + rail_h},
+                      TS::PANEL_U32);
+
+    // Chevron toggle: right edge of the rail.
+    const float chev_w = k_chevron_w * s;
+    ImGui::SetCursorScreenPos({canvas_x + canvas_w - chev_w, rail_y});
+    ImGui::PushStyleColor(ImGuiCol_Button,        TS::PANEL_2);
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, Darken(TS::PANEL_2, 0.06f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive,  Darken(TS::PANEL_2, 0.12f));
+    if (ImGui::Button(s_rail_collapsed ? "^##rail" : "v##rail", {chev_w, rail_h}))
+        s_rail_collapsed = !s_rail_collapsed;
+    ImGui::PopStyleColor(3);
+
+    ImGui::End();
+}
+
+} // namespace TS

--- a/src/ui/ts_app.cpp
+++ b/src/ui/ts_app.cpp
@@ -41,7 +41,7 @@ void DrawAppShell()
     const float body_y   = header_h;
     const float body_h   = dh - header_h;
     const float canvas_x = sidebar_w;
-    const float canvas_w = dw - sidebar_w;
+    const float canvas_w = (dw > sidebar_w) ? (dw - sidebar_w) : 0.0f;
     // Guard: canvas_h never goes negative if window is smaller than expected.
     const float canvas_h = (body_h > rail_h) ? (body_h - rail_h) : 0.0f;
     const float rail_y   = body_y + canvas_h;
@@ -90,7 +90,8 @@ void DrawAppShell()
     // Chevron toggle: upper-right corner of the rail, fixed height.
     const float chev_w = k_chevron_w * s;
     const float chev_h = k_chevron_h * s;
-    ImGui::SetCursorScreenPos({canvas_x + canvas_w - chev_w, rail_y});
+    const float chev_x = (canvas_w > chev_w) ? (canvas_x + canvas_w - chev_w) : canvas_x;
+    ImGui::SetCursorScreenPos({chev_x, rail_y});
     ImGui::PushStyleColor(ImGuiCol_Button,        TS::PANEL_2);
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, Darken(TS::PANEL_2, 0.06f));
     ImGui::PushStyleColor(ImGuiCol_ButtonActive,  Darken(TS::PANEL_2, 0.12f));

--- a/src/ui/ts_app.cpp
+++ b/src/ui/ts_app.cpp
@@ -65,14 +65,14 @@ void DrawAppShell()
     // ── Sidebar ──────────────────────────────────────────────────────────────
     dl->AddRectFilled({0.0f, body_y}, {sidebar_w, body_y + body_h}, TS::PANEL_U32);
 
-    // Collapse toggle: button pinned to the bottom of the sidebar.
+    // Collapse toggle: fixed-size button at the upper-left of the sidebar.
+    // Width is always k_icon_rail_w so the button doesn't resize on expand/collapse.
     const float tgl_h = k_toggle_h * s;
-    const float tgl_y = body_y + body_h - tgl_h;
-    ImGui::SetCursorScreenPos({0.0f, tgl_y});
+    ImGui::SetCursorScreenPos({0.0f, body_y});
     ImGui::PushStyleColor(ImGuiCol_Button,        TS::PANEL_2);
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, Darken(TS::PANEL_2, 0.06f));
     ImGui::PushStyleColor(ImGuiCol_ButtonActive,  Darken(TS::PANEL_2, 0.12f));
-    if (ImGui::Button(s_sidebar_collapsed ? ">##sb" : "<##sb", {sidebar_w, tgl_h}))
+    if (ImGui::Button(s_sidebar_collapsed ? ">##sb" : "<##sb", {k_icon_rail_w * s, tgl_h}))
         s_sidebar_collapsed = !s_sidebar_collapsed;
     ImGui::PopStyleColor(3);
 

--- a/src/ui/ts_app.cpp
+++ b/src/ui/ts_app.cpp
@@ -1,11 +1,10 @@
 // src/ui/ts_app.cpp
-// Static app shell — five layout zones, collapse toggles, no content.
+// Static app shell — four layout zones, collapse toggles, no content.
 //
 // Zone summary:
 //   Header        full width, 48px, always visible       (TS::HEADER)
 //   Sidebar       left, 280px | 40px icon rail           (TS::PANEL)
 //   Canvas        fills remaining space                   (TS::BG_SOFT)
-//   Toolbar       floating child, top-left of canvas     (TS::PANEL)
 //   Sequence rail bottom, 120px | 24px strip             (TS::PANEL)
 
 #include "ts_app.h"
@@ -23,9 +22,6 @@ namespace {
     constexpr float k_rail_strip  = 24.0f;
     constexpr float k_toggle_h    = 32.0f;  // sidebar collapse button height
     constexpr float k_chevron_w   = 48.0f;  // rail chevron button width
-    constexpr float k_toolbar_w   = 44.0f;
-    constexpr float k_toolbar_h   = 140.0f;
-    constexpr float k_pad         = 8.0f;   // toolbar inset from canvas edge
 }
 
 static bool s_sidebar_collapsed = false;
@@ -84,14 +80,6 @@ void DrawAppShell()
     dl->AddRectFilled({canvas_x, body_y},
                       {canvas_x + canvas_w, body_y + canvas_h},
                       TS::BG_SOFT_U32);
-
-    // ── Toolbar (floating child, overlaid on top-left of canvas) ─────────────
-    ImGui::SetCursorScreenPos({canvas_x + k_pad * s, body_y + k_pad * s});
-    ImGui::PushStyleColor(ImGuiCol_ChildBg, TS::PANEL);
-    ImGui::BeginChild("##toolbar", {k_toolbar_w * s, k_toolbar_h * s}, false,
-                      ImGuiWindowFlags_NoScrollbar);
-    ImGui::EndChild();
-    ImGui::PopStyleColor();
 
     // ── Sequence Rail ─────────────────────────────────────────────────────────
     dl->AddRectFilled({canvas_x, rail_y},

--- a/src/ui/ts_app.cpp
+++ b/src/ui/ts_app.cpp
@@ -21,7 +21,8 @@ namespace {
     constexpr float k_rail_h      = 120.0f;
     constexpr float k_rail_strip  = 32.0f;
     constexpr float k_toggle_h    = 32.0f;  // sidebar collapse button height
-    constexpr float k_chevron_w   = 48.0f;  // rail chevron button width
+    constexpr float k_chevron_w   = 48.0f;  // rail chevron button width  -- constant across open/collapsed
+    constexpr float k_chevron_h   = 32.0f;  // rail chevron button height -- constant across open/collapsed
 }
 
 static bool s_sidebar_collapsed = false;
@@ -88,7 +89,7 @@ void DrawAppShell()
 
     // Chevron toggle: upper-right corner of the rail, fixed height.
     const float chev_w = k_chevron_w * s;
-    const float chev_h = k_toggle_h  * s;
+    const float chev_h = k_chevron_h * s;
     ImGui::SetCursorScreenPos({canvas_x + canvas_w - chev_w, rail_y});
     ImGui::PushStyleColor(ImGuiCol_Button,        TS::PANEL_2);
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, Darken(TS::PANEL_2, 0.06f));

--- a/src/ui/ts_app.h
+++ b/src/ui/ts_app.h
@@ -1,0 +1,6 @@
+// src/ui/ts_app.h
+// Static app shell: five zones, collapse behavior, no content.
+
+#pragma once
+
+namespace TS { void DrawAppShell(); }


### PR DESCRIPTION
## Summary

Implements the static app shell (`src/ui/ts_app.cpp`) with four layout zones,
collapse behavior, and DPI-aware sizing. Closes #19.

## Zones

| Zone | Sizing | Token |
|---|---|---|
| Header | full width, 48px | `TS::HEADER` |
| Sidebar | 280px ↔ 40px icon rail | `TS::PANEL` |
| Canvas | fills remaining space | `TS::BG_SOFT` |
| Sequence rail | 120px ↔ 32px strip | `TS::PANEL` |

All sizing constants are 1× reference values multiplied by `TS::ui_scale` at
every use site. Canvas height is guarded against underflow at small window sizes.
SDL minimum window height set to `900px × ui_scale`.

## Changes from the original issue spec

**Toolbar removed.** The issue included a floating toolbar child window overlaid
on the canvas. It was removed before merge — no content was going inside it and
it added dead code with no acceptance criteria to verify.

**Sidebar toggle moved to upper-left, fixed size.** The initial implementation
placed the toggle at the bottom of the sidebar and stretched it to the full
sidebar width, which caused it to resize on every expand/collapse. The button is
now pinned to the top-left corner at a fixed `40×32px`, matching the icon rail
width so it never changes size.

**Collapsed rail strip widened to 32px.** The issue specified 24px. After seeing
it rendered, 32px was chosen for better click target size.

**Rail chevron is fixed-size at the upper-right.** The issue didn't constrain the
button height. The initial implementation stretched the chevron to the full rail
height (120px when open, 24px when collapsed). It is now a fixed `48×32px` button
at the top-right corner in both states, with a dedicated `k_chevron_h` constant
so its size is decoupled from the rail height.

## Test plan

- [ ] All four zones render at correct proportions at 1×, 1.25×, 1.5× `ui_scale`
- [ ] Sidebar collapses to 40px icon rail; toggle button stays 40×32px in both states
- [ ] Sequence rail collapses to 32px strip; canvas fills the reclaimed height
- [ ] Rail chevron is 48×32px in both open and collapsed states
- [ ] Window cannot be resized below 900px height
- [ ] No hardcoded pixel values — all sizing goes through `TS::ui_scale`